### PR TITLE
debugging Windows number of nodes issue

### DIFF
--- a/nimbleQuad/R/build_laplace_aghq.R
+++ b/nimbleQuad/R/build_laplace_aghq.R
@@ -2061,7 +2061,7 @@ buildAGHQ <- nimbleFunction(
                         print("Choice of nQuad would yield >50000 nodes for ",lenInternalRENodeSets[i],
                               " integration dimensions in conditionally independent set ", i)
                         print(nQuad)
-                        print(lenInternalRENodeSet)
+                        print(lenInternalRENodeSets)
                         stop("That is too many nodes.")
                     }
                 }

--- a/nimbleQuad/R/build_laplace_aghq.R
+++ b/nimbleQuad/R/build_laplace_aghq.R
@@ -2060,6 +2060,8 @@ buildAGHQ <- nimbleFunction(
                     if(nQuad * log(lenInternalRENodeSets[i]) > threshold) {
                         print("Choice of nQuad would yield >50000 nodes for ",lenInternalRENodeSets[i],
                               " integration dimensions in conditionally independent set ", i)
+                        print(nQuad)
+                        print(lenInternalRENodeSet)
                         stop("That is too many nodes.")
                     }
                 }


### PR DESCRIPTION
This adds some print statements to see if we can get more info about why Windows is reporting:

```
Choice of nQuad would yield >50000 nodes for 1.41421 integration dimensions in conditionally independent set 46
── Error: AGH Quadrature 1D Check MLE. ─────────────────────────────────────────
Error in `cmQuad$updateSettings(nQuad = 35)`: That is too many nodes
```

In particular - how could we possible get sqrt(2) dimensions given `lenInternalRENodeSets` are always determined from calling `length` on a vector of nodes...