### PR TITLE
Fix memory problems in `findMarginalPosteriorDensity`

### DIFF
--- a/nimbleQuad/R/Laplace.R
+++ b/nimbleQuad/R/Laplace.R
@@ -2086,7 +2086,7 @@ buildAGHQ <- nimbleFunction(
     pTransform_fixed <- 0
     pTransform_index_fixed <- 1
     pTransform_indices_other <- numeric(2)
-    test_ptrans_values <- numeric(2)
+#    test_ptrans_values <- numeric(2)
 
     ## The nimbleList definitions AGHQuad_params and AGHQuad_summary
     ## have moved to predefined nimbleLists.
@@ -2410,7 +2410,7 @@ buildAGHQ <- nimbleFunction(
     },
     calcLogDens_pTransformedFix1 = function(pTransform = double(1)){
       pTransform_star <- replaceOneVec(pTransform)
-      test_ptrans_values <<- pTransform_star
+#      test_ptrans_values <<- pTransform_star
 
       ans <- calcLogDens(pTransform_star, trans = TRUE, 
                          includeJacobian = includeJacobian_, 
@@ -2467,7 +2467,7 @@ buildAGHQ <- nimbleFunction(
     },
     gr_LogDens_pTransformedFix1 = function(pTransform = double(1)){
       pTransform_star <- replaceOneVec(pTransform)
-      test_ptrans_values <<- pTransform_star
+#      test_ptrans_values <<- pTransform_star
       ans <- gr_LogDens(pTransform_star, trans = TRUE, 
                            includeJacobian = includeJacobian_, 
                            includePrior = includePrior_)
@@ -2542,7 +2542,7 @@ buildAGHQ <- nimbleFunction(
                        includePrior = includePrior,
                        includeJacobian = includeJacobian,
                        hessian = hessian,
-                       parscale = "transform")
+                       parscale = "transformed")
 
       return(maxRes)
       returnType(optimResultNimbleList())                       
@@ -2581,10 +2581,15 @@ buildAGHQ <- nimbleFunction(
       ## Use of AD-based gradient requires fix to handling of gradient of prior. // CJP 2025-04-03
       if( !keepOneFixed_ ){
         optRes <- optim(pStartTransform, calcLogDens_pTransformed, #  gr_LogDens_pTransformed, 
-                        method = outerOptimMethod_, control = outerOptimControl_, hessian = hessian)      
-      }else{
+                        method = outerOptimMethod_, control = outerOptimControl_, hessian = hessian)
+        p <- paramsTransform$inverseTransform(optRes$par)
+        ## Could this be dangerous compilation-wise if $par and p are different lengths? // CJP 2025-04-27
+        if(parscale == "real") optRes$par <- p
+      } else {
         optRes <- optim(pStartTransform[pTransform_indices_other], calcLogDens_pTransformedFix1, # gr_LogDens_pTransformedFix1, 
-                        method = outerOptimMethod_, control = outerOptimControl_, hessian = hessian)                
+                        method = outerOptimMethod_, control = outerOptimControl_, hessian = hessian)
+        fullpar <- replaceOneVec(optRes$par)
+        p <- paramsTransform$inverseTransform(fullpar)
       }
       setLogDensType()  ## Reset it to default to posterior.
       keepOneFixed_ <<- FALSE ## Can only be switched on by calling findMax_fixedp.
@@ -2601,9 +2606,8 @@ buildAGHQ <- nimbleFunction(
                 "            Use `checkInnerConvergence(TRUE)` to see details.")
 
       ## Back transform results to original scale if requested.
-      p <- paramsTransform$inverseTransform(optRes$par)
-      if(parscale == "real") optRes$par <- p
-      setModelValues(p) ## Make sure the model object contains all the updated parameter values.
+      
+      setModelValues(p) ## Make sure the model object contains all the updated parameter values. 
  
       ## Returns on transformed scale just like optim.
       return(optRes)

--- a/nimbleQuad/R/approxPosterior.R
+++ b/nimbleQuad/R/approxPosterior.R
@@ -50,7 +50,7 @@ buildNestedApprox <- nimbleFunction(
         messageIfVerbose("Building nested posterior approximation for the following node sets:\n",
                          " - parameter nodes: ", makeNodeString(paramNodes, model), "\n",
                          " - latent nodes: ", makeNodeString(latentNodes, model), "\n",
-                         "using ", hyperGridRule, " grid for the parameters and ", ifelse(nQuadInner > 1, "AGHQ", "Laplace"), " approximation for the latent nodes.")
+                         " with ", hyperGridRule, " grid for the parameters and ", ifelse(nQuadInner > 1, "AGHQ", "Laplace"), " approximation for the latent nodes.")
  
         if(length(intersect(latentNodes, paramNodes)))
             stop("some nodes appear in both the parameter and latent sets")

--- a/nimbleQuad/R/approxPosterior.R
+++ b/nimbleQuad/R/approxPosterior.R
@@ -338,7 +338,7 @@ buildNestedApprox <- nimbleFunction(
         },
         calcSkewedSD = function() {
             ## Require the grid to have been built and the mode found.
-            buildHyperGrid()
+            buildHyperGrid(nQuadUpdate = nQuadOuter)
 
             setTransformations(transformMethod)
             logSkewedWgt <<- 0
@@ -376,7 +376,7 @@ buildNestedApprox <- nimbleFunction(
         ## Calculate theta on the quadrature grid points. AGHQ or CCD.
         ## Stores all values we need for simulation inference on the latent nodes.
         calcHyperGrid = function(skew = logical(0, default = TRUE)) {
-            buildHyperGrid()
+            buildHyperGrid(nQuadUpdate = nQuadOuter)
             setTransformations(transformMethod)
             nGrid <- theta_grid$gridSize()
 
@@ -510,7 +510,7 @@ buildNestedApprox <- nimbleFunction(
                 
                 if (gridTransformMethod == "spectral") {
                     E <- eigen(subsetNegHess, symmetric = TRUE)
-                    for (d in 1:theta_length) {
+                    for (d in 1:(theta_length-1)) {
                         Atransform_i[, d] <- E$vectors[, d]/sqrt(E$values[d])
                     }
                     logDetNegHessThetai <- sum(log(E$values))
@@ -518,7 +518,7 @@ buildNestedApprox <- nimbleFunction(
                     Atransform_i <- chol(subsetNegHess)
                     logDetNegHessThetai <- 2 * sum(log(diag(Atransform_i)))
                 }
-                
+
                 logDensi <- 0
                 nimCat("(", i, ")")
                 for (j in 1:nQuadGrid) {
@@ -529,7 +529,6 @@ buildNestedApprox <- nimbleFunction(
                                                 method = gridTransformMethod)
                         thetaj[other_theta_indices] <- theta_tmp
                         postLogDensij <- innerMethods$calcLogDens_pTransformed(pTransform = thetaj)
-                        
                         logDensi <- logDensi + exp(postLogDensij - maxPostDensi) * theta_marg_grid$weights(indx = j)[1]
                     } else {
                         logDensi <- logDensi + theta_marg_grid$weights(indx = j)[1]

--- a/nimbleQuad/R/quadratureGrids.R
+++ b/nimbleQuad/R/quadratureGrids.R
@@ -458,8 +458,8 @@ inner_cache_methods = nimbleFunction(
                                     cholesky = innerNegHessChol[k, jStart:(jStart + condIndptSets[j] - 1),
                                                                 jStart:(jStart + condIndptSets[j] - 1)],
                                     prec_param = TRUE)
+                    jStart <- jStart + condIndptSets[j]
                 }
-                jStart <- jStart + condIndptSets[j]
             }
             returnType(double(2))
             return(val)

--- a/nimbleQuad/R/runNestedApprox.R
+++ b/nimbleQuad/R/runNestedApprox.R
@@ -80,7 +80,7 @@ approxSummary <- R6Class("approxSummary",
             ## calc under CCD.
             if (!is.na(self$marginalLogLik_improved))
                 cat("Marginal log-likelihood (grid-based): ", self$marginalLogLik_improved, "(*)\n")
-            cat("(*) Marginal log-likelihood is invalid for improper priors and may not be useful\n   for non-informative priors.")
+            cat("(*) Marginal log-likelihood is invalid for improper priors and may not be useful\n   for non-informative priors.\n")
             
             invisible(self)
         },

--- a/nimbleQuad/R/runNestedApprox.R
+++ b/nimbleQuad/R/runNestedApprox.R
@@ -75,11 +75,12 @@ approxSummary <- R6Class("approxSummary",
             print(self$params)
             
             cat("\nMarginal log-likelihood (asymmetric Gaussian approximation): ",
-                self$marginalLogLik, "\n")
+                self$marginalLogLik, "(*)\n")
             ## Careful with ref to AGHQ here as we do at the moment allow 'improved'
             ## calc under CCD.
             if (!is.na(self$marginalLogLik_improved))
-                cat("Marginal log-likelihood (grid-based): ", self$marginalLogLik_improved, "\n")
+                cat("Marginal log-likelihood (grid-based): ", self$marginalLogLik_improved, "(*)\n")
+            cat("(*) Marginal log-likelihood is invalid for improper priors and may not be useful\n   for non-informative priors.")
             
             invisible(self)
         },
@@ -311,10 +312,16 @@ sampleLatentNodes <- function(summary, n = 1000, includeParams = FALSE) {
         nms <- nms[1]
     colnames(samples) <- c("index", nms)
     if (includeParams) {
-        paramValues <- getParamGrid()  ## `getParamGrid` needs to be written as a nestedApprox nf method, returning `theta_grid$nodes`.
-        paramValues <- t(apply(paramValues, 1, Rapprox$innerMethods$paramsTransform))
-        paramSamples <- paramValues[samples[, "index"], ]
-        colnames(paramSamples) <- Rapprox$paramNodesComponents
+        paramValues <- summary$approx$getParamGrid()
+        if(summary$originalScale) {
+            paramValues <- apply(paramValues, 1, Rapprox$innerMethods$paramsTransform$inverseTransform)
+            if(is.null(dim(paramValues)))
+                paramValues <- matrix(paramValues, ncol = 1) else paramValues <- t(paramValues)
+        }
+        paramSamples <- paramValues[samples[, "index"], , drop = FALSE]
+        if(summary$originalScale) {
+            colnames(paramSamples) <- Rapprox$paramNodesComponents
+        } else colnames(paramSamples) <- paste0('param', seq_len(Rapprox$npar))
         samples <- cbind(samples, paramSamples)
     }
     summary$samples <- samples[, -1, drop = FALSE]

--- a/nimbleQuad/tests/testthat/nested-1d1d.R
+++ b/nimbleQuad/tests/testthat/nested-1d1d.R
@@ -1,0 +1,281 @@
+## Code for checking 1 latent, 1 parameter cases.
+## These need to be transitioned into actual tests.
+
+## d=1 case, posterior for variance, sd a bit skewed, but not near 0.
+
+dig00 <- nimbleFunction(
+    run = function(x = double(0), log = logical(0, default = FALSE)) {
+        returnType(double(0))
+        if(log) return(-log(x)) else return(1/x)
+    }, buildDerivs = TRUE)
+
+registerDistributions(list(dig00=list(BUGSdist="dig00()",range=c(0,Inf))))
+
+## can't use dinvgamma(0,0) as that gives density of 0
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(mu, sd = sqrt(sigma2))
+    mu ~ dflat()
+    sigma2 ~ dig00() # Gelman Sec. 3.2: pi(sigma2) \propto 1/sigma2
+})
+
+
+set.seed(1)
+n <- 30
+m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n),
+                 inits = list(mu = 0, sigma2 = 1), buildDerivs = TRUE)
+
+### marginal for sigma2 is IG((n-1)/2,(n-1)*s2/2)
+### marginal for mu is t(ybar, s2/n)
+qpts <- c(.025,.25,.5,.75,.975)
+
+qs <- qinvgamma(qpts,(n-1)/2, scale=(n-1)*var(m$y)/2)
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'sigma2')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+qs
+result
+result$improveMarginals('sigma2', nMarginalGrid = 5) # already much better
+result$improveMarginals('sigma2', nMarginalGrid = 7)
+result$improveMarginals('sigma2', nMarginalGrid = 9)
+result$improveMarginals('sigma2', nMarginalGrid = 11)
+result$improveMarginals('sigma2', nMarginalGrid = 31) # very good
+
+
+sigma2_direct <- rinvgamma(10000,(n-1)/2, scale=(n-1)*var(m$y)/2)
+sigma2_sample <- result$sampleParamNodes(10000)
+qqplot(sigma2_direct, sigma2_sample)
+
+
+mu_sample <- result$sampleLatentNodes(1000)
+mu_direct <- rt_nonstandard(1000, n-1, mean(m$y), sqrt(var(m$y)/n))
+qqplot(mu_direct, mu_sample)
+
+mu_sample <- result$sampleLatentNodes(1000, includeParams = TRUE)
+
+## Check results on transformed scale.
+result <- runNestedApprox(capprox, originalScale = FALSE)
+log(qs)
+result  
+result$improveMarginals(1, nMarginalGrid = 5)
+result$improveMarginals(1, nMarginalGrid = 31)
+
+logsigma2_sample <- result$sampleParamNodes(10000)
+qqplot(log(sigma2_direct), logsigma2_sample)
+
+mu_sample <- result$sampleLatentNodes(1000, includeParams = TRUE)
+
+
+## One doesn't need inner AGHQ here given exact normality for latent, but just make sure it runs.
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'sigma2',
+                            control = list(nQuadInner = 3))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+mu_sample <- result$sampleLatentNodes(100000)
+quantile(mu_sample, qpts)
+qt_nonstandard(qpts, n-1, mean(m$y), sqrt(var(m$y)/n))
+
+## Use more accurate outer integration.
+## This could in principle improve inference for latents,
+## but we'd probably need to knock down the MC simulation
+## by simulating more samples in `sampleLatentNodes`.
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'sigma2',
+                            control = list(nQuadOuter = 7))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+mu_sample2 <- result$sampleLatentNodes(100000)
+quantile(mu_sample2, qpts)
+
+## mimic INLA priors to compare to INLA
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(mu, sd = sqrt(1/tau))
+    mu ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 30
+m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n),
+                 inits = list(mu = 0, tau = 1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'tau')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+result
+
+result$improveMarginals('tau', nMarginalGrid = 11)
+
+mu_sample <- result$sampleLatentNodes(100000)
+apply(mu_sample, 2, qpts)
+
+cm <- compileNimble(m)
+mcmc <- buildMCMC(m)
+cmcmc <- compileNimble(mcmc, project = m)
+out <- runMCMC(cmcmc,niter=1000000)
+
+apply(out, 2, quantile, qpts)
+
+
+## INLA
+
+fit <- inla(y~1, family="gaussian", data=data.frame(y=m$y), quantiles = qpts)
+summary(fit)
+
+
+## direct estimation is quite uncertain
+n <- 1e6
+
+mus <- rnorm(n,0,sd=sqrt(1/.001))
+taus <- rgamma(n,1,rate=5e-5)
+
+theta <- cbind(mus,sqrt(1/taus))
+y <- m$y
+logpy <- apply(theta, 1, function(x) sum(dnorm(y,x[1],x[2],log=T)))
+log(mean(exp(logpy)))
+
+## Try with more constrained priors.
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(mu, sd = sigma)
+    mu ~ dnorm(0,sd=3)
+    sigma~dunif(0,5)
+})
+
+
+set.seed(1)
+n <- 30
+m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n),
+                 inits = list(mu = 0, sigma = 1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'sigma')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+result
+
+## direct
+
+n <- 1e7
+
+mus <- rnorm(n,0,sd=3)
+sigmas <- runif(n,0,5)
+
+theta <- cbind(mus,sigmas)
+y <- m$y
+logpy <- apply(theta, 1, function(x) sum(dnorm(y,x[1],x[2],log=T)))
+log(mean(exp(logpy)))  # -45.34829  vs. -45.35235 for improved and -45.36005 for AG
+
+## priors where I can use INLA too
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(mu, tau)
+    mu ~ dnorm(0, sd=3)
+    tau ~ dgamma(1, 1)
+})
+
+
+set.seed(1)
+n <- 30
+m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n),
+                 inits = list(mu = 0, tau = 1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'tau')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+result
+
+result$improveMarginals('tau', nMarginalGrid = 31)
+
+result
+
+## INLA
+
+tmp <- inla.set.control.fixed.default(prec=1/9)
+
+fit <- inla(y ~ 1,  family="gaussian", data=data.frame(y=y),quantiles = qpts,
+               control.family = list(
+                 hyper = list(
+                   prec = list(
+                     prior = "loggamma", param=c(1,1)))))
+
+# inla.models()$likelihood$gaussian$hyper
+
+summary(fit)
+
+## direct
+
+n <- 1e7
+
+mus <- rnorm(n,0,sd=3)
+sigmas <- sqrt(1/rgamma(n,1,1))
+
+theta <- cbind(mus,sigmas)
+y <- m$y
+logpy <- apply(theta, 1, function(x) sum(dnorm(y,x[1],x[2],log=T)))
+log(mean(exp(logpy)))  # -44.03872 (rather closer to nestedApprox than to INLA)
+
+
+
+## Now have a case where the posterior for the parameter is not symmetric
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(mu, sd = sqrt(sigma2))
+    mu ~ dflat()
+    sigma2 ~ dig00() # Gelman Sec. 3.2: pi(sigma2) \propto 1/sigma2
+})
+
+
+set.seed(1)
+n <- 30
+m <- nimbleModel(code, data = list(y = rnorm(n, 0, 0.1)), constants = list(n=n),
+                 inits = list(mu = 0, sigma2 = 1), buildDerivs = TRUE)
+
+### marginal for sigma2 is IG((n-1)/2,(n-1)*s2/2)
+### marginal for mu is t(ybar, s2/n)
+qpts <- c(.025,.25,.5,.75,.975)
+
+qs <- qinvgamma(qpts,(n-1)/2, scale=(n-1)*var(m$y)/2)
+
+approx <- buildNestedApprox(m, latentNodes = 'mu', hyperParamNodes = 'sigma2')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+qs
+result
+result$improveMarginals('sigma2', nMarginalGrid = 5) # already much better
+result$improveMarginals('sigma2', nMarginalGrid = 7)
+result$improveMarginals('sigma2', nMarginalGrid = 9)
+result$improveMarginals('sigma2', nMarginalGrid = 11)
+result$improveMarginals('sigma2', nMarginalGrid = 31) # very good
+
+
+sigma2_direct <- rinvgamma(10000,(n-1)/2, scale=(n-1)*var(m$y)/2)
+sigma2_sample <- result$sampleParamNodes(10000)
+qqplot(sigma2_direct, sigma2_sample)
+
+
+mu_sample <- result$sampleLatentNodes(1000)
+mu_direct <- rt_nonstandard(1000, n-1, mean(m$y), sqrt(var(m$y)/n))
+qqplot(mu_direct, mu_sample)
+

--- a/nimbleQuad/tests/testthat/nested-2d1d.R
+++ b/nimbleQuad/tests/testthat/nested-2d1d.R
@@ -1,0 +1,37 @@
+qpts <- c(.025,.25,.5,.75,.975)
+
+## d=1 case with two latents
+
+code <- nimbleCode({
+    for(i in 1:n)
+        y[i] ~ dnorm(b0 + b1*x[i], sd = sqrt(1/tau))
+    b0 ~ dnorm(0,.001)
+    b1 ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 30
+x <- rnorm(n)
+y <- 0.3*x + rnorm(n)
+m <- nimbleModel(code, data = list(y = y, x = x), constants = list(n=n),
+                 inits = list(b0 = 0, b1 = .5, tau = 1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = c('b0','b1'), hyperParamNodes = 'tau')
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+result
+
+result$improveMarginals('tau', nMarginalGrid = 31)
+
+mu_sample <- result$sampleLatentNodes(100000)
+apply(mu_sample, 2, quantile, qpts)
+
+## INLA
+
+library(INLA)
+fit <- inla(y~x, family="gaussian", data=data.frame(y=y,x=x), quantiles = qpts)
+summary(fit)

--- a/nimbleQuad/tests/testthat/nested-8d2d.R
+++ b/nimbleQuad/tests/testthat/nested-8d2d.R
@@ -1,0 +1,192 @@
+qpts <- c(.025,.25,.5,.75,.975)
+
+## should we explore non-centered version with a single parameter?
+
+## d=2 case with 8 latents
+
+code <- nimbleCode({
+    for(j in 1:J) {
+        for(i in 1:n)
+            y[i,j] ~ dpois(exp(lambda[j]))
+        lambda[j] ~ dnorm(mu, sd=sqrt(1/tau))
+    }
+    mu ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 10
+J <- 8
+lambda <- rnorm(J)
+mns <- rep(exp(lambda), each = n)
+y <- matrix(rpois(n*J, mns), ncol = J)
+m <- nimbleModel(code, data = list(y = y), constants = list(n=n, J=J),
+                 inits = list(lambda = rep(0,J), mu = 0, tau=1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = c('lambda'), hyperParamNodes = c('mu','tau'))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+result
+
+# `improveMarginals` is definitely needed and now results pretty close to INLA
+result$improveMarginals('tau', nMarginalGrid = 7) 
+result$improveMarginals('mu', nMarginalGrid = 7)
+
+latent_sample <- result$sampleLatentNodes(100000)
+apply(latent_sample, 2, quantile, qpts)
+# lambda values not nearly as good as INLA marginals
+
+
+## Do better outer approximation
+
+approx <- buildNestedApprox(m, latentNodes = c('lambda'), hyperParamNodes = c('mu','tau'),
+                            control = list(nQuadOuter=7))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+system.time(result <- runNestedApprox(capprox))  
+latent_sample <- result$sampleLatentNodes(100000)
+apply(latent_sample, 2, quantile, qpts)
+
+
+
+## non-centered - perhaps closer to INLA's treatment of only the group precision as hyperparameter?
+## This breaks conditional independence so presumably less accurate.
+
+code <- nimbleCode({
+    for(j in 1:J) {
+        for(i in 1:n)
+            y[i,j] ~ dpois(exp(lambda[j]))
+        lambda[j] ~ dnorm(mu, sd=sqrt(1/tau))
+    }
+    mu ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 10
+J <- 8
+lambda <- rnorm(J)
+mns <- rep(exp(lambda), each = n)
+y <- matrix(rpois(n*J, mns), ncol = J)
+m <- nimbleModel(code, data = list(y = y), constants = list(n=n, J=J),
+                 inits = list(lambda = rep(0,J), mu = 0, tau=1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = c('mu','lambda'), hyperParamNodes = c('tau'))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+result
+
+result$improveMarginals('tau', nMarginalGrid = 7)  # definitely needed, now pretty close to INLA
+
+latent_sample <- result$sampleLatentNodes(100000)
+apply(latent_sample, 2, quantile, qpts)  # not all that close to INLA for `mu`, but is close to uncorrected INLA latent samples for 'mu'
+## lambda values not nearly as good as INLA marginals
+
+## Try better approximation.
+approx <- buildNestedApprox(m, latentNodes = c('mu','lambda'), hyperParamNodes = c('tau'),
+                            control = list(nQuadOuter=7))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+latent_sample <- result$sampleLatentNodes(100000)
+apply(latent_sample, 2, quantile, qpts)  
+
+
+## INLA
+
+library(INLA)
+group <- as.factor(rep(1:J, each = n))
+yc <- c(y)
+formula <- y ~ 1 + f(group, model = "iid")
+fit <- inla(formula, family="poisson", data=data.frame(y=yc,group=group), quantiles = qpts,
+            control.compute=list(config = TRUE))
+summary(fit)
+
+fit$summary.random
+
+sampled <- inla.posterior.sample(n = 100000, fit)
+smp <- t(sapply(sampled, function(x) x$latent[81:89,1]))
+apply(smp, 2, quantile, qpts) # INLA's samples rather better than ours, perhaps because of mean+skew correction
+
+# Without correction - doesn't seem to make a big difference to do the corrections though perhaps a bit worse, but ours are still rather worse.
+sampled <- inla.posterior.sample(n = 100000, fit, skew.corr = FALSE, use.improved.mean = FALSE)
+smp2 <- t(sapply(sampled, function(x) x$latent[81:89,1]))
+apply(smp2, 2, quantile, qpts) 
+
+
+## MCMC
+
+code <- nimbleCode({
+    for(j in 1:J) {
+        for(i in 1:n)
+            y[i,j] ~ dpois(exp(mu + lambda[j]))
+        lambda[j] ~ dnorm(0, sd=sqrt(1/tau))
+    }
+    mu ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 10
+J <- 8
+lambda <- rnorm(J)
+mns <- rep(exp(lambda), each = n)
+y <- matrix(rpois(n*J, mns), ncol = J)
+m <- nimbleModel(code, data = list(y = y), constants = list(n=n, J=J),
+                 inits = list(lambda = rep(0,J), mu = 0, tau=1), buildDerivs = TRUE)
+cm <- compileNimble(m)
+mcmc <- buildHMC(m, monitors = c('mu','tau','lambda'))
+cmcmc <- compileNimble(mcmc, project=m)
+out <- runMCMC(cmcmc, niter=51000,nburnin=1000)
+
+apply(out[,c('mu','tau')], 2, quantile, qpts)
+
+
+tmp <- out[, grepl("lambda", colnames(out))]
+
+apply(tmp, 2, quantile, qpts)
+
+## centered
+tmp <- tmp + out[,'mu']
+apply(tmp, 2, quantile, qpts)
+
+
+
+### Noncentered but with fixed effect in parameters.
+
+code <- nimbleCode({
+    for(j in 1:J) {
+        for(i in 1:n)
+            y[i,j] ~ dpois(exp(mu+ lambda[j]))
+        lambda[j] ~ dnorm(0, sd=sqrt(1/tau))
+    }
+    mu ~ dnorm(0,.001)
+    tau~dgamma(1, rate=5e-5)
+})
+
+
+set.seed(1)
+n <- 10
+J <- 8
+lambda <- rnorm(J)
+mns <- rep(exp(lambda), each = n)
+y <- matrix(rpois(n*J, mns), ncol = J)
+m <- nimbleModel(code, data = list(y = y), constants = list(n=n, J=J),
+                 inits = list(lambda = rep(0,J), mu = 0, tau=1), buildDerivs = TRUE)
+
+approx <- buildNestedApprox(m, latentNodes = c('lambda'), hyperParamNodes = c('mu','tau'),
+                            control = list(nQuadOuter=7))
+cm <- compileNimble(m)
+capprox <- compileNimble(approx, project = m)
+result <- runNestedApprox(capprox)
+
+latent_sample <- result$sampleLatentNodes(100000)
+apply(latent_sample, 2, quantile, qpts) # Not any better.

--- a/nimbleQuad/tests/testthat/penicillin.R
+++ b/nimbleQuad/tests/testthat/penicillin.R
@@ -1,0 +1,77 @@
+library(nimbleQuad)
+
+## Note that INLA's default prior is somewhat informative here in terms of intercept.
+## Not clear it's useful to relax that as key here is to assess accuracy
+## for model as constructed.
+
+data(penicillin, package="faraway")
+
+qpts <- c(.025,.25,.5,.75,.975)
+
+code <- nimbleCode({
+    for(i in 1:n) {
+        mu[i] <- inprod(b[1:nTreat], x[i, 1:nTreat]) + re[blend[i]]
+        y[i] ~ dnorm(mu[i], tau = Tau)
+    }
+    # Priors to match INLA
+    Tau ~ dgamma(1, 5e-05)
+    Tau_re ~ dgamma(1, 5e-05)
+    for( i in 1:nTreat ){ b[i] ~ dnorm(0, tau = 0.001) }
+    for( i in 1:nBlend ){ re[i] ~ dnorm(0, tau = Tau_re) }
+})
+X <- model.matrix(~treat, data = penicillin)
+data = list(y = penicillin$yield)
+constants = list(nTreat = 4, nBlend = 5, n = nrow(penicillin),
+                 x = X, blend = as.numeric(penicillin$blend))
+inits <- list(Tau = 1, Tau_re = 1, b = c(mean(data$y), rep(0,3)), re = rep(0,5))
+
+m <- nimbleModel(code, data = data, constants = constants,
+                 inits = inits, buildDerivs = TRUE)
+
+cm <- compileNimble(m)
+approx <- buildNestedApprox(model = m, hyperParamNodes = c('Tau', 'Tau_re'), latentNodes = c('b', 're'))
+capprox <- compileNimble(approx, project = m)
+
+result <- runNestedApprox(capprox)
+
+## Seems somewhat better than INLA.
+result$improveMarginals(nodes = 'Tau_re', nMarginalGrid=7)
+result$improveMarginals(nodes = 'Tau', nMarginalGrid=7)
+
+smp <- result$sampleLatentNodes(n=100000)
+apply(smp, 2, quantile, qpts)
+
+## Use more accurate outer grid, this gets fixed effects well-aligned with MCMC.
+## Random effects seem too uncertain, while INLA is too certain (but closer to MCMC).
+
+m <- nimbleModel(code, data = data, constants = constants,
+                 inits = inits, buildDerivs = TRUE)
+
+cm <- compileNimble(m)
+approx <- buildNestedApprox(model = m, hyperParamNodes = c('Tau', 'Tau_re'), latentNodes = c('b', 're'),
+                            control = list(nQuadOuter=7))
+capprox <- compileNimble(approx, project = m)
+
+smp <- result$sampleLatentNodes(n=100000)
+apply(smp, 2, quantile, qpts)
+
+
+## MCMC
+library(nimbleHMC)
+
+cm <- compileNimble(m)
+mcmc <- buildHMC(m, monitors = c('Tau_re','Tau','b','re'))
+cmcmc <- compileNimble(mcmc, project=m)
+out <- runMCMC(cmcmc, niter=51000,nburnin=1000)
+
+apply(out, 2, quantile, qpts)
+
+## INLA
+library(INLA)
+formula <- yield ~ treat + f(blend, model="iid")
+fit <- inla(formula, family = "gaussian", data=penicillin, 
+	control.compute=list(config = TRUE), quantiles = qpts)
+
+summary(fit)
+
+fit$summary.random

--- a/nimbleQuad/tests/testthat/test-nested.R
+++ b/nimbleQuad/tests/testthat/test-nested.R
@@ -1,0 +1,50 @@
+source(system.file(file.path('tests', 'testthat', 'test_utils.R'), package = 'nimble'))
+source(system.file(file.path('tests', 'testthat', 'AD_test_utils.R'), package = 'nimble'))
+EDopt <- nimbleOptions("enableDerivs")
+BMDopt <- nimbleOptions("buildModelDerivs")
+nimbleOptions(enableDerivs = TRUE)
+nimbleOptions(buildModelDerivs = TRUE)
+
+
+test_that("Error trapping for invalid models", {
+
+    ## Either no parameter or no latent nodes
+    code <- nimbleCode({
+        for(i in 1:n)
+            y[i] ~ dnorm(b0+b1*x[i], 1)
+        b0 ~ dnorm(0,1)
+        b1 ~ dnorm(0,1)
+    })
+    n <- 5
+    m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n, x=rnorm(n)))
+    
+    expect_error(buildNestedApprox(m), "No latent nodes detected in model")
+    expect_error(buildNestedApprox(m, hyperParamNodes = c('b0','b1')), "No latent nodes detected in model")
+    expect_error(buildNestedApprox(m, latentNodes = c('b0','b1')), "No parameter nodes detected in model")
+
+    ## Missing priors
+
+    code <- nimbleCode({
+        for(i in 1:n)
+            y[i] ~ dnorm(b0+b1*x[i], sd = sigma)
+        b0 ~ dnorm(0,sd = 10)
+        ## b1 ~ dnorm(0,sd = 10)  # Missing
+        sigma ~ dhalfflat()
+    })
+    n <- 50
+    m <- nimbleModel(code, data = list(y = rnorm(n)), constants = list(n=n, x=rnorm(n)))
+    
+    expect_error(buildNestedApprox(m, latentNodes = c('b0','b1'), hyperParamNodes = 'sigma'),
+                 "do not have prior distributions")
+
+})
+
+
+
+
+
+
+
+
+nimbleOptions(enableDerivs = EDopt)
+nimbleOptions(buildModelDerivs = BMDopt)


### PR DESCRIPTION
This fixes two memory/access problems related to `findMarginalPosteriorDensity`.

1. In `findMarginalPosteriorDensity`, we were not respecting that `Atransform_i` is d-1 by d-1 when filling it.
2. In `optimize` in Laplace, we were passing a `d-1` length value into `paramsTransform$inverseTransform`.

For $d=3$, these caused crashes with error messages related to memory use.

Strangely (and probably why not detected until now), for $d=2$, things ran fine.  I am confused why this would be the case, but perhaps it's not important to understand why.

@paul-vdb would be helpful if you'd give this a second eye. 