### PR TITLE
Improve setup one ah quad

### DIFF
--- a/nimbleQuad/R/Laplace.R
+++ b/nimbleQuad/R/Laplace.R
@@ -83,13 +83,11 @@ setup_OneAGHQuad <- function(model, paramNodes, randomEffectsNodes, calcNodes, c
 
   paramDeps <- model$getDependencies(paramNodes, determOnly = TRUE, self=FALSE)
   if(length(paramDeps) > 0) {
-    keep_paramDeps <- logical(length(paramDeps))
-    for(i in seq_along(paramDeps)) {
-      if(any(paramDeps[i] == calcNodes)) keep_paramDeps[i] <- FALSE
-      else {
+    keep_paramDeps <- logical(length(paramDeps))  # all FALSE
+    matched <- which(!paramDeps %in% calcNodes)
+    for(i in matched) {
         nextDeps <- model$getDependencies(paramDeps[i])
         keep_paramDeps[i] <- any(nextDeps %in% calcNodes)
-      }
     }
     paramDeps <- paramDeps[keep_paramDeps]
   }

--- a/nimbleQuad/R/Laplace.R
+++ b/nimbleQuad/R/Laplace.R
@@ -1833,6 +1833,9 @@ buildAGHQ <- nimbleFunction(
     check <- extractControlElement(control, 'check', TRUE)
     innerOptimWarning <- extractControlElement(control, 'innerOptimWarning', FALSE)
 
+    if(!is.Rmodel(model))
+        stop("`model` must be an R model, created by calling `nimbleModel`")
+    
     if(nQuad %% 2 == 0)
       messageIfVerbose("  [Note] For computational efficiency, it is recommended to use an odd number of quadrature points.")
     if(nQuad > 35) {
@@ -2605,7 +2608,6 @@ buildAGHQ <- nimbleFunction(
       # optRes <- optim(pStartTransform, calcLogLik_pTransformed, gr_logLik_pTransformed, method = outerOptimMethod_, control = outerOptimControl_, hessian = hessian)
 
       setLogDensType(includeJacobian = includeJacobian, includePrior = includePrior)
-      ## Use of AD-based gradient requires fix to handling of gradient of prior. // CJP 2025-04-03
       if( !keepOneFixed_ ){
         if(outerOptimUseAD) {
             optRes <- optim(pStartTransform, calcLogDens_pTransformed, gr_logDens_pTransformed, 

--- a/nimbleQuad/R/Laplace.R
+++ b/nimbleQuad/R/Laplace.R
@@ -82,14 +82,9 @@ setup_OneAGHQuad <- function(model, paramNodes, randomEffectsNodes, calcNodes, c
   nre  <- length(model$expandNodeNames(randomEffectsNodes, returnScalarComponents = TRUE))
 
   paramDeps <- model$getDependencies(paramNodes, determOnly = TRUE, self=FALSE)
-  if(length(paramDeps) > 0) {
-    keep_paramDeps <- logical(length(paramDeps))  # all FALSE
-    matched <- which(!paramDeps %in% calcNodes)
-    for(i in matched) {
-        nextDeps <- model$getDependencies(paramDeps[i])
-        keep_paramDeps[i] <- any(nextDeps %in% calcNodes)
-    }
-    paramDeps <- paramDeps[keep_paramDeps]
+  if(length(paramDeps)) {
+    calcNodesParents <- model$getParents(calcNodes)
+    paramDeps <- paramDeps[paramDeps %in% calcNodesParents]  
   }
   innerCalcNodes <- calcNodes
   calcNodes <- model$expandNodeNames(c(paramDeps, calcNodes), sort = TRUE)

--- a/nimbleQuad/R/Laplace.R
+++ b/nimbleQuad/R/Laplace.R
@@ -83,8 +83,8 @@ setup_OneAGHQuad <- function(model, paramNodes, randomEffectsNodes, calcNodes, c
 
   paramDeps <- model$getDependencies(paramNodes, determOnly = TRUE, self=FALSE)
   if(length(paramDeps)) {
-    calcNodesParents <- model$getParents(calcNodes)
-    paramDeps <- paramDeps[paramDeps %in% calcNodesParents]  
+    calcNodesParents <- model$getParents(calcNodes, determOnly = TRUE)
+    paramDeps <- paramDeps[!paramDeps %in% calcNodes & paramDeps %in% calcNodesParents]  
   }
   innerCalcNodes <- calcNodes
   calcNodes <- model$expandNodeNames(c(paramDeps, calcNodes), sort = TRUE)

--- a/nimbleQuad/R/buildNestedApprox.R
+++ b/nimbleQuad/R/buildNestedApprox.R
@@ -18,7 +18,9 @@ buildNestedApprox <- nimbleFunction(
         ## see how they work.
         control$innerOptimStart <- extractControlElement(control, "innerOptimStart",
                                                          "zero")
-
+        if(!is.Rmodel(model))
+            stop("`model` must be an R model, created by calling `nimbleModel`")
+        
         inferenceNodes <- model$getNodeNames(includeData = FALSE, stochOnly = TRUE)
         if(!missing(paramNodes) && !all(model$expandNodeNames(paramNodes) %in% inferenceNodes))
             stop("some elements of `paramNodes` do not have prior distributions")


### PR DESCRIPTION
This tries to reduce dependencies stuff in determination of `paramDeps` in `setup_OneAGHquad` in this block:

```
  paramDeps <- model$getDependencies(paramNodes, determOnly = TRUE, self=FALSE)
  if(length(paramDeps) > 0) {
    keep_paramDeps <- logical(length(paramDeps))
    for(i in seq_along(paramDeps)) {
      if(any(paramDeps[i] == calcNodes)) keep_paramDeps[i] <- FALSE
      else {
        nextDeps <- model$getDependencies(paramDeps[i])
        keep_paramDeps[i] <- any(nextDeps %in% calcNodes)
      }
    }
    paramDeps <- paramDeps[keep_paramDeps]
  }
```

If the params are involved in, say, a long vec of linear predictor values, this for loop can be massive. (For example in the Bernoulli GLMM example in my recent NCT efficiency issue, if one has fixed effects in params rather than in latents so that `paramDeps` includes all the linear predictor values.)

This fix first rules out all the `paramDeps` that are in `calcNodes` in a vectorized `%in%` call before doing a (hopefully much smaller or non-existent) loop.

I think this will address most problematic cases. I am still a bit nervous that there could be cases where there are a lot of paramDeps that are not directly in calcNodes and that need to be looped over, but I don't have a use case in mind.


@perrydv would appreciate your eye on this as it looks like you committed this in commit 0ebb7d3df9 in June 2024 (but @paul-vdb co-authored so perhaps the request is for him).
